### PR TITLE
Change to destructuring assignment for http-proxy-middleware

### DIFF
--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,8 +1,8 @@
-const proxy = require('http-proxy-middleware');
+const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function(app) {
   app.use(
-    proxy('/.netlify/functions/', {
+    createProxyMiddleware('/.netlify/functions/', {
       target: 'http://localhost:9000/',
       pathRewrite: {
         '^/\\.netlify/functions': '',


### PR DESCRIPTION
This is the current method for using http-proxy-middleware. 

(Things break with just `const proxy = ...`)